### PR TITLE
Raw logging capability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ import (
 )
 
 defer gol.Flush()
-gol.SetOption(gol.Llongfile | gol.Ldate | gol.Ltime | gol.Lmicroseconds)
+gol.SetOption(gol.Llongfile | gol.Ldate | gol.Ltime | gol.Lmicroseconds | gol.Llevel)
 gol.Debug("Hello, gol!!!")
 gol.Criticalf("Hello from %s", runtime.GOOS)
 
@@ -153,7 +153,7 @@ import (
 )
 
 defer gol.Flush()
-gol.SetOption(gol.Llongfile | gol.Ldate | gol.Ltime | gol.Lmicroseconds)
+gol.SetOption(gol.Llongfile | gol.Ldate | gol.Ltime | gol.Lmicroseconds | gol.Llevel)
 gol.AddLogAdapter("anonymous", a)
 gol.Debug("Hello, gol!!!")
 gol.Criticalf("Hello from %s", runtime.GOOS)

--- a/gol_test.go
+++ b/gol_test.go
@@ -17,7 +17,7 @@ var _adapter = fakeSync.NewAdapter()
 func init() {
 	logger.AddLogAdapter("fake", _adapter)
 	logger.RemoveAdapter(CONSOLELOGGER)
-	logger.SetOption(LogOption(0))
+	logger.SetOption(LogOption(Llevel))
 }
 
 func TestDebug(t *testing.T) {

--- a/gollogOption.go
+++ b/gollogOption.go
@@ -103,6 +103,10 @@ func (l *gollog) generateLog(callDepth int, level level.LogLevel, msg string, bu
 
 	l.generatePrefix(buf, callDepth+1)
 
-	buf.Write(level.Bytes())
-	buf.WriteString(internal.JoinStrings(" ", msg, "\n"))
+	if l.option&(Llevel) != 0 {
+		buf.Write(level.Bytes())
+		buf.WriteString(internal.JoinStrings(" ", msg, "\n"))
+	} else {
+		buf.WriteString(internal.JoinStrings(msg, "\n"))
+	}
 }

--- a/gollog_test.go
+++ b/gollog_test.go
@@ -18,7 +18,7 @@ func init() {
 
 	_logger.AddLogAdapter("fake", _loggerAdapter)
 	_logger.RemoveAdapter(CONSOLELOGGER)
-	_logger.SetOption(LogOption(0))
+	_logger.SetOption(LogOption(Llevel))
 }
 
 func Test_gollog_Debug(t *testing.T) {

--- a/option.go
+++ b/option.go
@@ -25,6 +25,8 @@ const (
 	Lshortfile // final file name element and line number: d.go:23. overrides Llongfile
 	// LUTC print time as UTC format
 	LUTC // if Ldate or Ltime is set, use UTC rather than the local time zone
+	// Llevel output level on log line
+	Llevel // disable to write raw lines
 	// LstdFlags is the default header format
-	LstdFlags = Ldate | Ltime | Lshortfile // initial values for the standard logger
+	LstdFlags = Ldate | Ltime | Lshortfile | Llevel // initial values for the standard logger
 )


### PR DESCRIPTION
This change adds the ability to output raw log messages without
any boilerplate (i.e. timestamp, log level, filename, etc...).

* Adds standard option for log level (enabled by default)
* Adds logic in `generateLog` to skip output of log level.